### PR TITLE
Fix start menu & some pause menu bugs

### DIFF
--- a/Assets/Resources/Prefabs/VR/VRPlayer.prefab
+++ b/Assets/Resources/Prefabs/VR/VRPlayer.prefab
@@ -6293,6 +6293,12 @@ PrefabInstance:
       propertyPath: m_hasFontAssetChanged
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1041859971031687069, guid: 047157ac420f9344283db42053d3ffc5,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
+        type: 2}
     - target: {fileID: 1151348757973392123, guid: 047157ac420f9344283db42053d3ffc5,
         type: 3}
       propertyPath: m_fontAsset
@@ -6568,6 +6574,12 @@ PrefabInstance:
       propertyPath: m_Material
       value: 
       objectReference: {fileID: 2100000, guid: 811e18983fdccea48b47d6095fce3407, type: 2}
+    - target: {fileID: 2781737734532198177, guid: 047157ac420f9344283db42053d3ffc5,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
+        type: 2}
     - target: {fileID: 2851688081322630145, guid: 047157ac420f9344283db42053d3ffc5,
         type: 3}
       propertyPath: m_Material
@@ -7245,6 +7257,12 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7147285672686622342, guid: 047157ac420f9344283db42053d3ffc5,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
+        type: 2}
     - target: {fileID: 7224750900465194340, guid: 047157ac420f9344283db42053d3ffc5,
         type: 3}
       propertyPath: m_Material
@@ -7328,6 +7346,12 @@ PrefabInstance:
       propertyPath: m_hasFontAssetChanged
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7749050709525567848, guid: 047157ac420f9344283db42053d3ffc5,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
+        type: 2}
     - target: {fileID: 7769268492454796684, guid: 047157ac420f9344283db42053d3ffc5,
         type: 3}
       propertyPath: m_fontAsset

--- a/Assets/Sandbox/Cameron/Scenes/Menu Testing.unity
+++ b/Assets/Sandbox/Cameron/Scenes/Menu Testing.unity
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21f6d33b366c7869cdf100289c89fd487fec34bd36ff4cdb2ac162fb381e318d
+size 78385

--- a/Assets/Sandbox/Cameron/Scenes/Menu Testing.unity.meta
+++ b/Assets/Sandbox/Cameron/Scenes/Menu Testing.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83a11746a58e53b42a01b4ed022a05af
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Management/SettingsManager.cs.meta
+++ b/Assets/Scripts/Management/SettingsManager.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 300
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Management/SettingsSwitcher.cs.meta
+++ b/Assets/Scripts/Management/SettingsSwitcher.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 1000
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/VR/ComfortSettingsMenu.cs.meta
+++ b/Assets/Scripts/VR/ComfortSettingsMenu.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 600
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/VR/VideoSettingsMenu.cs.meta
+++ b/Assets/Scripts/VR/VideoSettingsMenu.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 400
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Custom/AppData.cs.meta
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Custom/AppData.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 100
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Custom/ComfortManager.cs.meta
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Custom/ComfortManager.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 500
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Custom/EventManager.cs.meta
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Custom/EventManager.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 200
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
The execution order of the start menu appears to be fully fixed.
The pause menu now uses normal text for dropdowns because for some reason the overlay text doesn't work in dropdowns even though it works everywhere else.